### PR TITLE
Fix DRF Request wrapping in search view

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -164,10 +164,8 @@ def global_search(request):
     paginator = PageNumberPagination()
     paginator.page_size = page_size
 
-    # Use request to paginate
-    from rest_framework.request import Request
-    drf_request = Request(request)
-    paginated_results = paginator.paginate_queryset(all_results, drf_request)
+    # Paginate the results
+    paginated_results = paginator.paginate_queryset(all_results, request)
 
     return paginator.get_paginated_response({
         'query': query,


### PR DESCRIPTION
The global_search view was attempting to wrap a DRF Request object in another DRF Request object, causing an AssertionError. Since the view is decorated with @api_view, the request parameter is already a DRF Request object and doesn't need additional wrapping.

Fixes the error:
"The `request` argument must be an instance of `django.http.HttpRequest`, not `rest_framework.request.Request`."