### PR TITLE
Implement payment receipt upload API

### DIFF
--- a/shop/serializers/payment.py
+++ b/shop/serializers/payment.py
@@ -1,0 +1,63 @@
+# shop/serializers/payment.py
+
+from rest_framework import serializers
+from ..models import Payment, PaymentTransaction
+
+
+class PaymentReceiptUploadSerializer(serializers.Serializer):
+    """Serializer for uploading payment receipt"""
+
+    order_id = serializers.UUIDField(required=True)
+    payment_receipt = serializers.ImageField(required=True)
+
+    def validate_payment_receipt(self, value):
+        """Validate the uploaded file is an image"""
+        if value.size > 5 * 1024 * 1024:  # 5MB limit
+            raise serializers.ValidationError("Image file too large. Max size is 5MB.")
+        return value
+
+
+class PaymentSerializer(serializers.ModelSerializer):
+    """Serializer for Payment model"""
+
+    class Meta:
+        model = Payment
+        fields = [
+            "id",
+            "order",
+            "amount",
+            "status",
+            "gateway",
+            "currency",
+            "reference_id",
+            "transaction_id",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "id",
+            "created_at",
+            "updated_at",
+        ]
+
+
+class PaymentTransactionSerializer(serializers.ModelSerializer):
+    """Serializer for PaymentTransaction model"""
+
+    class Meta:
+        model = PaymentTransaction
+        fields = [
+            "id",
+            "payment",
+            "amount",
+            "transaction_id",
+            "provider_status",
+            "payment_receipt",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "id",
+            "created_at",
+            "updated_at",
+        ]

--- a/shop/urls.py
+++ b/shop/urls.py
@@ -17,6 +17,7 @@ from .views.payment import (
     PaymentStatusView,
     PaymentMethodsView,
     PaymentVerificationView,
+    PaymentReceiptUploadView,
 )
 
 
@@ -55,4 +56,9 @@ urlpatterns = [
         name="payment_status",
     ),
     path("payments/methods/", PaymentMethodsView.as_view(), name="payment_methods"),
+    path(
+        "payments/upload-receipt/",
+        PaymentReceiptUploadView.as_view(),
+        name="upload_receipt",
+    ),
 ]


### PR DESCRIPTION
Implement /api/shop/payments/upload-receipt/ endpoint that allows users to upload payment receipts for manual verification.

Changes:
- Created PaymentReceiptUploadSerializer for validating upload requests
- Added PaymentReceiptUploadView with multipart form support
- Integrated with existing Payment and PaymentTransaction models
- Added proper authentication and authorization checks
- Configured URL routing for the new endpoint

The endpoint accepts order_id and payment_receipt (image file), creates or retrieves a Payment record with MANUAL gateway, and creates a PaymentTransaction with the uploaded receipt for admin verification.