### PR TITLE
Implement story part image upload API

### DIFF
--- a/stories/urls.py
+++ b/stories/urls.py
@@ -1,7 +1,13 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
-from .views import StoryViewSet, StoryTemplateViewSet, StoryCollectionViewSet, ImageAssetViewSet
+from .views import (
+    StoryViewSet,
+    StoryTemplateViewSet,
+    StoryCollectionViewSet,
+    ImageAssetViewSet,
+    StoryPartImageUploadView,
+)
 
 router = DefaultRouter()
 router.register(r'templates', StoryTemplateViewSet)
@@ -10,5 +16,6 @@ router.register(r'images', ImageAssetViewSet, basename='image')
 router.register(r'', StoryViewSet, basename='story')
 
 urlpatterns = [
+    path('upload-part-image/', StoryPartImageUploadView.as_view(), name='upload-part-image'),
     path('', include(router.urls)),
 ]


### PR DESCRIPTION
- Add StoryPartImageUploadSerializer to validate upload requests with 10MB file size limit
- Add StoryPartImageUploadView API endpoint at /api/stories/upload-part-image/
- Endpoint accepts story_id, part_position, and image via multipart/form-data
- Validates user ownership and story part existence before updating illustration
- Fix missing ValidationError import in views.py