### PR TITLE
Remove authentication requirement for completed stories

### DIFF
--- a/stories/views.py
+++ b/stories/views.py
@@ -177,9 +177,9 @@ class StoryViewSet(viewsets.ModelViewSet):
 
         return Response(StorySerializer(story).data)
 
-    @action(detail=False, methods=["get"], url_path="completed")
+    @action(detail=False, methods=["get"], url_path="completed", permission_classes=[permissions.AllowAny])
     def completed_stories(self, request):
-        """Get all completed stories from all users"""
+        """Get all completed stories from all users - publicly accessible"""
         completed_stories = Story.objects.filter(
             status=StoryStatus.COMPLETED
         ).select_related("author", "story_template").prefetch_related("parts")


### PR DESCRIPTION
Remove authentication requirement from the completed_stories endpoint to allow anyone to view completed stories without logging in.