### PR TITLE
Add profile image upload API endpoint

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -139,6 +139,28 @@ class UserSerializer(serializers.ModelSerializer):
         return None
 
 
+class ProfileImageSerializer(serializers.ModelSerializer):
+    """Serializer for uploading profile image"""
+    class Meta:
+        model = User
+        fields = ["profile_image"]
+
+    def validate_profile_image(self, value):
+        """Validate the uploaded image"""
+        if value:
+            # Check file size (limit to 5MB)
+            if value.size > 5 * 1024 * 1024:
+                raise serializers.ValidationError("Image file size cannot exceed 5MB.")
+
+            # Check file type
+            allowed_types = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp']
+            if value.content_type not in allowed_types:
+                raise serializers.ValidationError(
+                    "Only JPEG, PNG, GIF, and WebP images are allowed."
+                )
+        return value
+
+
 class UserLoginSerializer(serializers.Serializer):
     email = serializers.EmailField()
     password = serializers.CharField(style={"input_type": "password"}, write_only=True)

--- a/users/urls.py
+++ b/users/urls.py
@@ -3,7 +3,7 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from rest_framework_simplejwt.views import TokenRefreshView
-from .views import UserView, AddressViewSet, AuthView
+from .views import UserView, AddressViewSet, AuthView, ProfileImageView
 
 from .views import (
     CustomTokenObtainPairView,
@@ -28,6 +28,7 @@ urlpatterns = [
     path("reset-password/", reset_password, name="reset-password"),
     path("", include(router.urls)),
     path("me/", UserView.as_view(), name="user-profile"),
+    path("me/profile-image/", ProfileImageView.as_view(), name="profile-image"),
     path(
         "addresses/<str:pk>/set_default/",
         AddressViewSet.as_view({"post": "set_default"}),

--- a/users/views.py
+++ b/users/views.py
@@ -25,6 +25,7 @@ from .serializers import (
     AddressSerializer,
     UserLoginSerializer,
     UserRegistrationSerializer,
+    ProfileImageSerializer,
 )
 
 
@@ -43,6 +44,43 @@ class UserView(APIView):
             serializer.save()
             return Response(serializer.data)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class ProfileImageView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request):
+        """Upload or update profile image"""
+        serializer = ProfileImageSerializer(
+            request.user,
+            data=request.data,
+            partial=True
+        )
+
+        if serializer.is_valid():
+            serializer.save()
+            return Response(
+                {
+                    "message": "Profile image uploaded successfully",
+                    "profile_image": serializer.data.get('profile_image')
+                },
+                status=status.HTTP_200_OK
+            )
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request):
+        """Delete profile image"""
+        user = request.user
+        if user.profile_image:
+            user.profile_image.delete(save=True)
+            return Response(
+                {"message": "Profile image deleted successfully"},
+                status=status.HTTP_200_OK
+            )
+        return Response(
+            {"error": "No profile image to delete"},
+            status=status.HTTP_400_BAD_REQUEST
+        )
 
 
 class AddressViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
Add dedicated endpoint for uploading and managing profile images:
- Add ProfileImageSerializer with validation for image type and size
- Add ProfileImageView with POST (upload) and DELETE (remove) methods
- Add /api/users/me/profile-image/ endpoint
- Implement file size limit (5MB) and type validation (JPEG, PNG, GIF, WebP)