### PR TITLE
Add pagination support to stories API

### DIFF
--- a/stories/pagination.py
+++ b/stories/pagination.py
@@ -1,0 +1,11 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class CustomPageNumberPagination(PageNumberPagination):
+    """
+    Custom pagination class that allows clients to specify page size via query parameter
+    while enforcing reasonable limits.
+    """
+    page_size = 10  # Default page size
+    page_size_query_param = 'page_size'  # Allow client to override via ?page_size=X
+    max_page_size = 100  # Maximum limit for page size to prevent abuse

--- a/stories/views.py
+++ b/stories/views.py
@@ -26,6 +26,7 @@ from .serializers import (
     ImageAssetSerializer,
     StoryPartImageUploadSerializer,
 )
+from .pagination import CustomPageNumberPagination
 
 
 class StoryTemplateViewSet(viewsets.ReadOnlyModelViewSet):
@@ -77,6 +78,7 @@ class StoryTemplateViewSet(viewsets.ReadOnlyModelViewSet):
 
 class StoryViewSet(viewsets.ModelViewSet):
     serializer_class = StorySerializer
+    pagination_class = CustomPageNumberPagination
 
     def get_queryset(self):
         return Story.objects.filter(author=self.request.user)


### PR DESCRIPTION
- Created CustomPageNumberPagination class that allows clients to override page size via query parameter
- Set default page_size to 10 and max_page_size to 100 to prevent abuse
- Applied custom pagination to StoryViewSet to fix issue where page_size parameter was being ignored
- Fixes issue where /api/stories/?page_size=12 was returning only 10 stories