### PR TITLE
Implement product comments API endpoints

### DIFF
--- a/shop/urls.py
+++ b/shop/urls.py
@@ -19,6 +19,10 @@ from .views.payment import (
     PaymentVerificationView,
     PaymentReceiptUploadView,
 )
+from .views.comment import (
+    product_comments_list_create,
+    product_comment_delete,
+)
 
 
 app_name = "shop"
@@ -35,6 +39,18 @@ wagtail_api_router.register_endpoint("product-info", ProductInfoPageAPIViewSet)
 
 urlpatterns = [
     path("", include(router.urls)),
+    # Product comments endpoints
+    path(
+        "products/<slug:slug>/comments/",
+        product_comments_list_create,
+        name="product_comments",
+    ),
+    path(
+        "products/<slug:slug>/comments/<uuid:comment_id>/",
+        product_comment_delete,
+        name="product_comment_delete",
+    ),
+    # Payment endpoints
     path(
         "payments/request/<uuid:order_id>/",
         PaymentRequestView.as_view(),

--- a/shop/views/__init__.py
+++ b/shop/views/__init__.py
@@ -1,0 +1,8 @@
+# shop/views/__init__.py
+
+from .comment import product_comments_list_create, product_comment_delete
+
+__all__ = [
+    'product_comments_list_create',
+    'product_comment_delete',
+]

--- a/shop/views/comment.py
+++ b/shop/views/comment.py
@@ -1,0 +1,78 @@
+# shop/views/comment.py
+from django.shortcuts import get_object_or_404
+from rest_framework import status, permissions
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.response import Response
+
+from core.views import list_comments, create_comment
+from core.models import Comment
+from ..models.product import Product
+
+
+@api_view(['GET', 'POST'])
+@permission_classes([permissions.AllowAny])
+def product_comments_list_create(request, slug):
+    """
+    GET /shop/products/{slug}/comments/ - List product comments
+    POST /shop/products/{slug}/comments/ - Create product comment
+
+    This is a product-specific wrapper around the generic comment system.
+    """
+    # Get the product by slug
+    product = get_object_or_404(Product, slug=slug)
+
+    if request.method == 'GET':
+        return list_comments(request, product)
+    elif request.method == 'POST':
+        return create_comment(request, product)
+
+
+@api_view(['DELETE'])
+@permission_classes([permissions.IsAuthenticated])
+def product_comment_delete(request, slug, comment_id):
+    """
+    DELETE /shop/products/{slug}/comments/{comment_id}/ - Delete a product comment
+
+    Only the comment author or admin can delete comments.
+    """
+    # Get the product by slug (to validate it exists)
+    product = get_object_or_404(Product, slug=slug)
+
+    # Get the comment
+    try:
+        comment = Comment.objects.get(
+            id=comment_id,
+            is_deleted=False
+        )
+    except Comment.DoesNotExist:
+        return Response({
+            "code": "COMMENT_NOT_FOUND",
+            "message": "Comment not found",
+            "severity": "error"
+        }, status=status.HTTP_404_NOT_FOUND)
+
+    # Verify the comment belongs to this product
+    from django.contrib.contenttypes.models import ContentType
+    content_type = ContentType.objects.get_for_model(product)
+    if comment.content_type != content_type or str(comment.object_id) != str(product.id):
+        return Response({
+            "code": "COMMENT_NOT_FOUND",
+            "message": "Comment not found for this product",
+            "severity": "error"
+        }, status=status.HTTP_404_NOT_FOUND)
+
+    # Check permissions
+    # User must be the comment author or an admin
+    if comment.user != request.user and not request.user.is_staff:
+        return Response({
+            "code": "FORBIDDEN",
+            "message": "You don't have permission to delete this comment",
+            "severity": "error"
+        }, status=status.HTTP_403_FORBIDDEN)
+
+    # Soft delete
+    comment.is_deleted = True
+    comment.save()
+
+    # Return 204 No Content
+    return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Add product-specific comment endpoints that wrap the generic comment system with frontend-friendly URLs:
- GET /shop/products/{slug}/comments/ - List product comments
- POST /shop/products/{slug}/comments/ - Create product comment
- DELETE /shop/products/{slug}/comments/{commentId}/ - Delete comment

These endpoints provide a more intuitive API for the frontend while reusing the existing generic Comment model and business logic from the core app.