### PR TITLE
Fix unauthorized error on public stories API

### DIFF
--- a/stories/views.py
+++ b/stories/views.py
@@ -83,10 +83,10 @@ class StoryViewSet(viewsets.ModelViewSet):
 
     def get_permissions(self):
         """
-        Allow anonymous access for retrieving individual completed stories.
+        Allow anonymous access for retrieving individual completed stories and completed stories list.
         Require authentication for all other actions.
         """
-        if self.action == 'retrieve':
+        if self.action in ['retrieve', 'completed_stories']:
             return [permissions.AllowAny()]
         return [permissions.IsAuthenticated()]
 


### PR DESCRIPTION
The completed_stories action had permission_classes=[permissions.AllowAny] but the get_permissions() method was overriding this by only checking for the 'retrieve' action. Updated get_permissions() to also allow anonymous access for the 'completed_stories' action.